### PR TITLE
feat: Avoid same background twice

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -1,3 +1,3 @@
-wallpaper_dir: /home/yago/Pictures/Wallpapers
+wallpaper_dir: ~/Pictures/Wallpapers
 betterlockscreen: false
 sleep_time: 1800

--- a/src/path.rs
+++ b/src/path.rs
@@ -46,15 +46,27 @@ impl ToString for File {
     }
 }
 
-impl From<String> for File {
-    fn from(path: String) -> Self {
-        File::new(PathBuf::from(path)).unwrap()
+impl TryFrom<String> for crate::path::File {
+    type Error = &'static str;
+
+    fn try_from(path: String) -> Result<Self, Self::Error> {
+        if let Some(file) = File::new(PathBuf::from(path)) {
+            Ok(file)
+        } else {
+            Err("failed to create file")
+        }
     }
 }
 
-impl From<PathBuf> for File {
-    fn from(path: PathBuf) -> Self {
-        File::new(path).unwrap()
+impl TryFrom<PathBuf> for File {
+    type Error = &'static str;
+
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        if let Some(file) = File::new(path) {
+            Ok(file)
+        } else {
+            Err("failed to create file")
+        }
     }
 }
 

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -73,7 +73,9 @@ pub fn get_random_wallpaper(settings: &Settings) -> Option<File> {
         })
         .collect::<Vec<_>>();
 
-    if files.is_empty() {
+    let files_len = files.len();
+
+    if files_len == 0 {
         return None;
     }
 
@@ -83,7 +85,7 @@ pub fn get_random_wallpaper(settings: &Settings) -> Option<File> {
 
     if let Some(current_wallpaper) = get_current_wallpaper() {
         let current_wallpaper = current_wallpaper.to_string();
-        while *path.to_str()? == current_wallpaper && files.len() > 1 {
+        while *path.to_str()? == current_wallpaper && files_len > 1 {
             random_number = rand::thread_rng().gen_range(0..files.len());
             path = files.get(random_number).unwrap().as_ref().unwrap().path();
         }

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -83,7 +83,7 @@ pub fn get_random_wallpaper(settings: &Settings) -> Option<File> {
 
     if let Some(current_wallpaper) = get_current_wallpaper() {
         let current_wallpaper = current_wallpaper.to_string();
-        while path.to_str()?.to_owned() == current_wallpaper && files.len() > 1 {
+        while *path.to_str()? == current_wallpaper && files.len() > 1 {
             random_number = rand::thread_rng().gen_range(0..files.len());
             path = files.get(random_number).unwrap().as_ref().unwrap().path();
         }

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// Panics if the file $HOME/.fehbg does not exist.
 ///
-pub fn get_current_wallpaper() -> File {
+pub fn get_current_wallpaper() -> Option<File> {
     let feh_raw = read_to_string(format!(
         "{}/.fehbg",
         home::home_dir()
@@ -48,7 +48,7 @@ pub fn get_current_wallpaper() -> File {
         .trim_matches('\'')
         .to_string();
 
-    File::from(wallpaper_path)
+    File::try_from(wallpaper_path).ok()
 }
 
 /// Gets a random wallpaper from the wallpaper directory.
@@ -77,8 +77,18 @@ pub fn get_random_wallpaper(settings: &Settings) -> Option<File> {
         return None;
     }
 
-    let random_number = rand::thread_rng().gen_range(0..files.len());
-    let path = files.get(random_number).unwrap().as_ref().unwrap().path();
+    let mut random_number = rand::thread_rng().gen_range(0..files.len());
+
+    let mut path = files.get(random_number).unwrap().as_ref().unwrap().path();
+
+    if let Some(current_wallpaper) = get_current_wallpaper() {
+        let current_wallpaper = current_wallpaper.to_string();
+        while path.to_str()?.to_owned() == current_wallpaper && files.len() > 1 {
+            random_number = rand::thread_rng().gen_range(0..files.len());
+            path = files.get(random_number).unwrap().as_ref().unwrap().path();
+        }
+    }
+
     File::new(path)
 }
 
@@ -151,7 +161,8 @@ pub fn get_next_animated_wallpaper(settings: &Settings, path: &File) -> Option<I
 
 /// Gets the next wallpaper.
 pub fn get_next_wallpaper(settings: &Settings) -> ImagePath {
-    let mut current_wallpaper = get_current_wallpaper();
+    let mut current_wallpaper =
+        get_current_wallpaper().unwrap_or(get_random_wallpaper(settings).unwrap());
     let mut new_wallpaper = get_random_wallpaper(settings)
         .expect("failed to get random wallpaper, not enough wallpapers in the wallpaper directory");
     if current_wallpaper.is_animated(settings) {
@@ -171,9 +182,17 @@ pub fn update_animated(settings: &Settings, path: &File) -> ImagePath {
     if let Some(next_wallpaper) = next_wallpaper {
         next_wallpaper
     } else {
-        get_random_wallpaper_file(settings).expect(
+        let mut new_random = get_random_wallpaper(settings).expect(
             "failed to get random wallpaper, not enough wallpapers in the wallpaper directory",
-        )
+        );
+        if new_random.is_animated(settings) {
+            update_animated(settings, &new_random)
+        } else {
+            match new_random {
+                File::Image(img) => img,
+                File::Folder(_) => unreachable!(),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Wallshift now avoids setting the same background twice in a row.

I also made part of the code more robust.